### PR TITLE
ci: add basic build check workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,38 @@
+name: PR Build Check
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew :app:assembleDebug
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: build-reports
+        path: |
+          **/build/reports/
+          **/build/outputs/logs/
+        retention-days: 7


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow for PR build validation
- Runs `./gradlew :app:assembleDebug` on every pull request
- Uses JDK 17 and latest Gradle setup actions
- Uploads build artifacts on failure for debugging

## Test plan
- [x] Workflow file follows GitHub Actions best practices
- [x] Uses appropriate Java/Gradle versions for Android development
- [x] Will verify CI runs and passes when this PR is created

🤖 Generated with [Claude Code](https://claude.ai/code)