### PR TITLE
feat(nav): add destinations for detail/main/sub to NavGraph

### DIFF
--- a/.agent/workflows/adaptive-android-v2.yaml
+++ b/.agent/workflows/adaptive-android-v2.yaml
@@ -1,0 +1,111 @@
+# adaptive-android-v2.yaml
+# ----------------------------------------------------------------------
+# 変更理由（Changelog / Rationale）
+# - v1 運用中に、Detail / MainContent / SubContent が NavGraph 未登録であることが判明。
+# - これらは単なる Composable として存在していたため、実際の画面遷移ができない。
+# - v2 では NavGraph への destinations 追加、エントリ関数の分離、配線、戻る、deep link
+#   までを段階的に組み込むマイルストーンを新設した。
+# - 既存 v1 は互換維持（modules-and-deps / top-and-tabs / list-second-level / subcontent-third-level）。
+# ----------------------------------------------------------------------
+
+workflow: "Adaptive layouts playground (Android v2)"
+principles:
+  - "Each task must compile (:app:assembleDebug or module-local build)."
+  - "One commit per task."
+  - "Keep adaptive usage behind :core:ui wrappers."
+  - "Respect depends_on strictly."
+  - "Changes must stay within module_scope."
+
+# 既存の v1 マイルストーンは省略（そのまま流用）。以下は v2 での追加分。
+milestones:
+  - name: "nav-graph-second-third-level"
+    description: "Detail / MainContent / SubContent を NavGraph に登録し、一覧から辿れるようにする"
+
+    tasks:
+      - id: "register-destinations-detail-main-sub"
+        goal: ":feature:navigation の NavGraph に detail/{id}, main/{id}, sub/{id} を追加する"
+        module_scope: [":feature:navigation", ":core:route"]
+        # v1 の navigation 基盤と list module がある前提
+        depends_on: ["navigation-feature", "listdetail-impl"]
+        actions:
+          - "NavGraph 定義（:feature:navigation）に以下の destination を追加:"
+          - "  - composable(route = \"detail/{id}\", arguments = [navArgument(\"id\") { type = NavType.StringType }]) {"
+          - "      val id = it.arguments?.getString(\"id\")!!"
+          - "      DetailRoute(id)"
+          - "    }"
+          - "  - composable(route = \"main/{id}\", arguments = [navArgument(\"id\") { type = NavType.StringType }]) {"
+          - "      val id = it.arguments?.getString(\"id\")!!"
+          - "      MainContentRoute(id)"
+          - "    }"
+          - "  - composable(route = \"sub/{id}\", arguments = [navArgument(\"id\") { type = NavType.StringType }]) {"
+          - "      val id = it.arguments?.getString(\"id\")!!"
+          - "      SubContentRoute(id)"
+          - "    }"
+          - ":core:route の AppRoute 拡張（routeName）と整合する route 文字列を使用すること。"
+          - "Run ./gradlew :feature:navigation:build"
+        verify:
+          - ":feature:navigation がビルド成功すること"
+        commit: "feat(nav): add destinations for detail/main/sub to NavGraph"
+        notes: "null 安全性のため requireNotNull などで id を検証しても良い"
+
+      - id: "entry-composables-in-feature-list"
+        goal: ":feature:list に DetailRoute / MainContentRoute / SubContentRoute のエントリ関数を追加する"
+        module_scope: [":feature:list"]
+        depends_on: ["register-destinations-detail-main-sub"]
+        actions:
+          - ":feature:list に以下の Composable エントリ関数を追加（既存 Screen を呼び出す）:"
+          - "  fun DetailRoute(id: String) { DetailScreen(id = id) }"
+          - "  fun MainContentRoute(id: String) { MainContentScreen(id = id) }"
+          - "  fun SubContentRoute(id: String) { SubContentScreen(parentId = id) }"
+          - "SubContentScreen.kt が無ければ新規作成（プレースホルダで可）。"
+          - "Run ./gradlew :feature:list:build"
+        verify:
+          - ":feature:list がビルド成功すること"
+          - "SubContentScreen が存在すること"
+        commit: "feat(list): add route entry composables for detail/main/sub"
+        notes: "Main/Detail のどちらで Sub を開くかは後続タスクで配線"
+
+      - id: "wire-navigation-from-list"
+        goal: "List → Detail/Main と MainContent → SubContent の遷移を配線する"
+        module_scope: [":feature:list", ":feature:navigation"]
+        depends_on: ["entry-composables-in-feature-list"]
+        actions:
+          - "ListScreen で item クリック時に navController.navigate(AppRoute.Detail(item.id).routeName)"
+          - "（必要なら）別操作で navController.navigate(AppRoute.MainContent(item.id).routeName) も追加"
+          - "MainContentScreen に \"サブを開く\" ボタンなどを追加し、"
+          - "navController.navigate(AppRoute.SubContent(id).routeName) を呼び出す"
+          - "Run ./gradlew :app:assembleDebug"
+        verify:
+          - "Home → List → 任意アイテム → Detail に遷移できる"
+          - "MainContent 経由で SubContent に遷移できる"
+          - "ビルド成功（:app:assembleDebug）"
+        commit: "feat(list): wire navigation to detail/main/sub routes from list and main"
+        notes: "NavController の取得は LocalContext/LocalNavController 等プロジェクト慣習に合わせる"
+
+      - id: "back-navigation-actions"
+        goal: "Detail / SubContent に戻る操作（navigateUp）を追加する"
+        module_scope: [":feature:list"]
+        depends_on: ["wire-navigation-from-list"]
+        actions:
+          - "DetailScreen と SubContentScreen に TopAppBar の戻るアイコンなどを設置し、navController.navigateUp() を呼ぶ"
+          - "戻り先が List / MainContent になることを確認"
+          - "Run ./gradlew :app:assembleDebug"
+        verify:
+          - "Detail → 戻る → List に戻る"
+          - "SubContent → 戻る → MainContent に戻る"
+          - "ビルド成功（:app:assembleDebug）"
+        commit: "chore(list): add navigateUp actions on detail and sub screens"
+
+      - id: "deeplinks-and-args-validation"
+        goal: "（任意）deep link と引数バリデーションを追加する"
+        module_scope: [":feature:navigation", ":feature:list"]
+        depends_on: ["back-navigation-actions"]
+        actions:
+          - "各 destination に navDeepLink を追加（例: myapp://detail/{id}, myapp://main/{id}, myapp://sub/{id}）"
+          - "id 取得部で require(id.isNotBlank()) などの簡易バリデーションを追加"
+          - "Run ./gradlew :app:assembleDebug"
+        verify:
+          - "deeplink で対象画面が開く（ログ等で確認）"
+          - "ビルド成功（:app:assembleDebug）"
+        commit: "chore(nav): add deeplinks and basic arg validation for detail/main/sub"
+        notes: "deeplink のスキーム/ホストはプロジェクトの package 名等に合わせて設定"

--- a/feature/navigation/src/main/kotlin/example/large/screen/playground/feature/navigation/AppNavigation.kt
+++ b/feature/navigation/src/main/kotlin/example/large/screen/playground/feature/navigation/AppNavigation.kt
@@ -17,10 +17,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import example.large.screen.playground.core.route.AppRoute
 import example.large.screen.playground.feature.home.HomeScreen
 import example.large.screen.playground.feature.list.ListDetailScreen
@@ -116,9 +118,48 @@ private fun AppNavHost(
         composable(SETTING_ROUTE) {
             SettingScreen()
         }
+        composable(
+            route = "detail/{id}",
+            arguments = listOf(navArgument("id") { type = NavType.StringType })
+        ) {
+            val id = it.arguments?.getString("id")!!
+            DetailRoute(id)
+        }
+        composable(
+            route = "main/{id}",
+            arguments = listOf(navArgument("id") { type = NavType.StringType })
+        ) {
+            val id = it.arguments?.getString("id")!!
+            MainContentRoute(id)
+        }
+        composable(
+            route = "sub/{id}",
+            arguments = listOf(navArgument("id") { type = NavType.StringType })
+        ) {
+            val id = it.arguments?.getString("id")!!
+            SubContentRoute(id)
+        }
     }
 }
 
+
+/**
+ * Temporary placeholder route functions - will be replaced in next task
+ */
+@Composable
+private fun DetailRoute(id: String) {
+    Text("Detail Route: $id")
+}
+
+@Composable
+private fun MainContentRoute(id: String) {
+    Text("Main Content Route: $id")
+}
+
+@Composable
+private fun SubContentRoute(id: String) {
+    Text("Sub Content Route: $id")
+}
 
 /**
  * Route string constants


### PR DESCRIPTION
## Summary
- Added NavGraph destinations for detail/{id}, main/{id}, sub/{id}
- Added navArgument support for string ID parameters
- Created temporary placeholder route functions (to be replaced in next task)
- Ensured route consistency with AppRoute.routeName extension

## Test plan
- [x] :feature:navigation builds successfully
- [x] NavGraph contains new composable destinations with proper arguments
- [x] Routes match AppRoute.routeName patterns ("detail/{id}", "main/{id}", "sub/{id}")

🤖 Generated with [Claude Code](https://claude.ai/code)