### PR TITLE
feat(list): add route entry composables for detail/main/sub

### DIFF
--- a/feature/list/src/main/kotlin/example/large/screen/playground/feature/list/RouteEntries.kt
+++ b/feature/list/src/main/kotlin/example/large/screen/playground/feature/list/RouteEntries.kt
@@ -1,0 +1,23 @@
+package example.large.screen.playground.feature.list
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Entry point composables for navigation destinations.
+ * These functions bridge between the navigation system and the actual screen implementations.
+ */
+
+@Composable
+fun DetailRoute(id: String) {
+    DetailScreen(itemId = id)
+}
+
+@Composable
+fun MainContentRoute(id: String) {
+    MainContentScreen(itemId = id)
+}
+
+@Composable
+fun SubContentRoute(id: String) {
+    SubContentScreen(parentId = id)
+}

--- a/feature/list/src/main/kotlin/example/large/screen/playground/feature/list/SubContentScreen.kt
+++ b/feature/list/src/main/kotlin/example/large/screen/playground/feature/list/SubContentScreen.kt
@@ -1,0 +1,38 @@
+package example.large.screen.playground.feature.list
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SubContentScreen(parentId: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Sub Content Screen",
+            style = MaterialTheme.typography.headlineMedium
+        )
+        Text(
+            text = "Parent ID: $parentId",
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+        Text(
+            text = "This is the third-level sub content screen, accessible from MainContent.",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+    }
+}

--- a/feature/navigation/src/main/kotlin/example/large/screen/playground/feature/navigation/AppNavigation.kt
+++ b/feature/navigation/src/main/kotlin/example/large/screen/playground/feature/navigation/AppNavigation.kt
@@ -25,7 +25,10 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import example.large.screen.playground.core.route.AppRoute
 import example.large.screen.playground.feature.home.HomeScreen
+import example.large.screen.playground.feature.list.DetailRoute
 import example.large.screen.playground.feature.list.ListDetailScreen
+import example.large.screen.playground.feature.list.MainContentRoute
+import example.large.screen.playground.feature.list.SubContentRoute
 import example.large.screen.playground.feature.setting.SettingScreen
 
 /**
@@ -142,24 +145,6 @@ private fun AppNavHost(
     }
 }
 
-
-/**
- * Temporary placeholder route functions - will be replaced in next task
- */
-@Composable
-private fun DetailRoute(id: String) {
-    Text("Detail Route: $id")
-}
-
-@Composable
-private fun MainContentRoute(id: String) {
-    Text("Main Content Route: $id")
-}
-
-@Composable
-private fun SubContentRoute(id: String) {
-    Text("Sub Content Route: $id")
-}
 
 /**
  * Route string constants


### PR DESCRIPTION
## Summary
- Created SubContentScreen.kt (missing third-level screen)
- Added RouteEntries.kt with DetailRoute, MainContentRoute, SubContentRoute functions
- Updated navigation module to use real entry functions instead of placeholders
- All entry functions properly call existing screen implementations

## Test plan
- [x] :feature:list builds successfully
- [x] SubContentScreen exists and follows existing screen patterns
- [x] Entry functions bridge navigation destinations to actual screens
- [x] Navigation module properly imports and uses new entry functions

🤖 Generated with [Claude Code](https://claude.ai/code)